### PR TITLE
Ensure MariaDB service is booted before making under CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mariadb:
-        image: mariadb
+        image: mariadb:10.4
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/mysql
+          --health-cmd="mysqladmin ping --host 127.0.0.1 --port 3306 --user root --password=rootpass"
+          --health-interval 2s
+          --health-timeout 10s
+          --health-retries 10
         ports:
         - 3306/tcp
         env:
@@ -21,7 +27,12 @@ jobs:
           MYSQL_USER: dogmatiq
           MYSQL_PASSWORD: dogmatiq
       postgres:
-        image: postgres
+        image: postgres:12.0-alpine
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 2s
+          --health-timeout 10s
+          --health-retries 10
         env:
           POSTGRES_PASSWORD: rootpass
         ports:

--- a/docker-stack.test.yml
+++ b/docker-stack.test.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   mariadb:
-    image: mariadb
+    image: mariadb:10.4
     environment:
       MYSQL_ROOT_PASSWORD: rootpass
       MYSQL_DATABASE: dogmatiq
@@ -13,7 +13,7 @@ services:
     volumes:
     - mariadb:/var/lib/mysql
   postgres:
-    image: postgres
+    image: postgres:12.0-alpine
     environment:
       POSTGRES_PASSWORD: rootpass
     ports:


### PR DESCRIPTION
This is achieved by adding healthchecks to force GitHub actions to wait until the service is healthly, and additionally configuring MariaDB to use a `tmpfs` filesystem for its data volume, which significantly decreases its boot time.