### PR TITLE
Projection compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Changed
+
+- **[BC]** Update to Dogma v0.10.0
+
+### Added
+
+- **[BC]** Add `sql.MessageHandler.Compact()`
+- **[BC]** Add `boltdb.MessageHandler.Compact()`
+
 ## [0.4.0] - 2020-06-29
 
 ### Added

--- a/boltdb/adaptor.go
+++ b/boltdb/adaptor.go
@@ -109,3 +109,8 @@ func (a *adaptor) UpdateResourceVersion(
 func (a *adaptor) DeleteResource(ctx context.Context, r []byte) error {
 	return deleteResource(ctx, a.db, a.key, r)
 }
+
+// Compact reduces the size of the projection's data.
+func (a *adaptor) Compact(ctx context.Context, s dogma.ProjectionCompactScope) error {
+	return a.MessageHandler.Compact(ctx, a.db, s)
+}

--- a/boltdb/adaptor_test.go
+++ b/boltdb/adaptor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dogmatiq/projectionkit/internal/adaptortest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"go.etcd.io/bbolt"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -226,6 +227,25 @@ var _ = Describe("type adaptor", func() {
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(v).To(BeEmpty())
+		})
+	})
+
+	Describe("func Closure()", func() {
+		It("forwards to the handler", func() {
+			handler.CompactFunc = func(
+				_ context.Context,
+				d *bbolt.DB,
+				_ dogma.ProjectionCompactScope,
+			) error {
+				Expect(d).To(BeIdenticalTo(db))
+				return errors.New("<error>")
+			}
+
+			err := adaptor.Compact(
+				context.Background(),
+				nil, // scope
+			)
+			Expect(err).To(MatchError("<error>"))
 		})
 	})
 })

--- a/boltdb/fixtures/handler.go
+++ b/boltdb/fixtures/handler.go
@@ -13,6 +13,7 @@ type MessageHandler struct {
 	ConfigureFunc   func(c dogma.ProjectionConfigurer)
 	HandleEventFunc func(context.Context, *bolt.Tx, dogma.ProjectionEventScope, dogma.Message) error
 	TimeoutHintFunc func(m dogma.Message) time.Duration
+	CompactFunc     func(context.Context, *bolt.DB, dogma.ProjectionCompactScope) error
 }
 
 // Configure configures the behavior of the engine as it relates to this
@@ -56,4 +57,16 @@ func (h *MessageHandler) TimeoutHint(m dogma.Message) time.Duration {
 	}
 
 	return 0
+}
+
+// Compact reduces the size of the projection's data.
+//
+// If h.CompactFunc is non-nil it returns h.CompactFunc(ctx,db,s), otherwise it
+// returns nil.
+func (h *MessageHandler) Compact(ctx context.Context, db *bolt.DB, s dogma.ProjectionCompactScope) error {
+	if h.CompactFunc != nil {
+		return h.CompactFunc(ctx, db, s)
+	}
+
+	return nil
 }

--- a/boltdb/handler.go
+++ b/boltdb/handler.go
@@ -62,4 +62,19 @@ type MessageHandler interface {
 	// a duration shorter than the hint is NOT RECOMMENDED, as this will likely
 	// lead to repeated message handling failures.
 	TimeoutHint(m dogma.Message) time.Duration
+
+	// Compact reduces the size of the projection's data.
+	//
+	// The implementation SHOULD attempt to decrease the size of the
+	// projection's data by whatever means available. For example, it may delete
+	// any unused data, or collapse multiple data sets into one.
+	//
+	// The context MAY have a deadline. The implementation SHOULD compact data
+	// using multiple small transactions, such that if the deadline is reached a
+	// future call to Compact() does not need to compact the same data.
+	//
+	// The engine SHOULD call Compact() repeatedly throughout the lifetime of
+	// the projection. The precise scheduling of calls to Compact() are
+	// engine-defined. It MAY be called concurrently with any other method.
+	Compact(ctx context.Context, db *bolt.DB, s dogma.ProjectionCompactScope) error
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dogmatiq/projectionkit
 go 1.13
 
 require (
-	github.com/dogmatiq/dogma v0.9.0
+	github.com/dogmatiq/dogma v0.10.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/google/uuid v1.1.2
 	github.com/lib/pq v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
-github.com/dogmatiq/dogma v0.9.0 h1:PGRUqBPVI76HhkxulEEvzxe+693pq9cfQxJWBCpV730=
-github.com/dogmatiq/dogma v0.9.0/go.mod h1:8TdjQ5jjV2DcCPb/jjHPgSrqU66H6092yMEIF5HGx0g=
+github.com/dogmatiq/dogma v0.10.0 h1:2kLivwq72nr6yF3/jpIA5U57IOmPRxeO+I9lE06IebE=
+github.com/dogmatiq/dogma v0.10.0/go.mod h1:8TdjQ5jjV2DcCPb/jjHPgSrqU66H6092yMEIF5HGx0g=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=

--- a/sql/adaptor.go
+++ b/sql/adaptor.go
@@ -133,3 +133,8 @@ func (a *adaptor) UpdateResourceVersion(
 func (a *adaptor) DeleteResource(ctx context.Context, r []byte) error {
 	return a.driver.DeleteResource(ctx, a.db, a.key, r)
 }
+
+// Compact reduces the size of the projection's data.
+func (a *adaptor) Compact(ctx context.Context, s dogma.ProjectionCompactScope) error {
+	return a.MessageHandler.Compact(ctx, a.db, s)
+}

--- a/sql/fixtures/handler.go
+++ b/sql/fixtures/handler.go
@@ -13,6 +13,7 @@ type MessageHandler struct {
 	ConfigureFunc   func(dogma.ProjectionConfigurer)
 	HandleEventFunc func(context.Context, *sql.Tx, dogma.ProjectionEventScope, dogma.Message) error
 	TimeoutHintFunc func(dogma.Message) time.Duration
+	CompactFunc     func(context.Context, *sql.DB, dogma.ProjectionCompactScope) error
 }
 
 // Configure configures the behavior of the engine as it relates to this
@@ -56,4 +57,16 @@ func (h *MessageHandler) TimeoutHint(m dogma.Message) time.Duration {
 	}
 
 	return 0
+}
+
+// Compact reduces the size of the projection's data.
+//
+// If h.CompactFunc is non-nil it returns h.CompactFunc(ctx,db,s), otherwise it
+// returns nil.
+func (h *MessageHandler) Compact(ctx context.Context, db *sql.DB, s dogma.ProjectionCompactScope) error {
+	if h.CompactFunc != nil {
+		return h.CompactFunc(ctx, db, s)
+	}
+
+	return nil
 }

--- a/sql/handler.go
+++ b/sql/handler.go
@@ -62,4 +62,19 @@ type MessageHandler interface {
 	// a duration shorter than the hint is NOT RECOMMENDED, as this will likely
 	// lead to repeated message handling failures.
 	TimeoutHint(m dogma.Message) time.Duration
+
+	// Compact reduces the size of the projection's data.
+	//
+	// The implementation SHOULD attempt to decrease the size of the
+	// projection's data by whatever means available. For example, it may delete
+	// any unused data, or collapse multiple data sets into one.
+	//
+	// The context MAY have a deadline. The implementation SHOULD compact data
+	// using multiple small transactions, such that if the deadline is reached a
+	// future call to Compact() does not need to compact the same data.
+	//
+	// The engine SHOULD call Compact() repeatedly throughout the lifetime of
+	// the projection. The precise scheduling of calls to Compact() are
+	// engine-defined. It MAY be called concurrently with any other method.
+	Compact(ctx context.Context, db *sql.DB, s dogma.ProjectionCompactScope) error
 }


### PR DESCRIPTION
<!------------------------------------------------------------------------------

A GOOD PULL REQUEST:

- Is small.
- Contains a single change that makes sense in isolation.
- Makes the code better.


A GOOD PULL REQUEST TITLE:

- Completes the sentence "If applied, this PR will ...".
- Is less than 50 characters.

Example: Allow for compaction of projections.


BEFORE YOU SUBMIT A PULL REQUEST:

- Read the contribution guidelines at https://github.com/dogmatiq/.github/CONTRIBUTING.md.
- Know what you are submitting.
- Review the entire diff line-by-line. If this is too hard, your PR is too big.

------------------------------------------------------------------------------->

#### What change does this introduce?

Updates `projectionkit` to support the "projection compaction" feature added in Dogma v0.10.0.

The BoltDB and SQL-specific projection `MessageHandler` interfaces now have a `Compact()` method similar to that of `dogma.ProjectionMessageHandler` with the addition of a `db` parameter.

#### What issues does this relate to?

It's based on dependabot PR #64.
It's also a blocker for https://github.com/dogmatiq/example/pull/78

#### Why make this change?

Projections implemented using `projectionkit` need access to the underlying database to perform their compaction.

#### Is there anything you are unsure about?

No