### PR TITLE
Test mysql driver with MySQL itself (not just MariaDB).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,21 @@ jobs:
     name: Continuous Integration
     runs-on: ubuntu-latest
     services:
+      mysql:
+        image: mysql:8
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/mysql
+          --health-cmd="mysqladmin ping --host 127.0.0.1 --port 3306 --user root --password=rootpass"
+          --health-interval 2s
+          --health-timeout 10s
+          --health-retries 10
+        ports:
+        - 3306/tcp
+        env:
+          MYSQL_ROOT_PASSWORD: rootpass
+          MYSQL_DATABASE: dogmatiq
+          MYSQL_USER: dogmatiq
+          MYSQL_PASSWORD: dogmatiq
       mariadb:
         image: mariadb:10.4
         options: >-
@@ -49,6 +64,7 @@ jobs:
       run: make ci
       env:
         CGO_ENABLED: "1"
+        DOGMATIQ_TEST_DSN_MYSQL_MYSQL: "root:rootpass@tcp(127.0.0.1:${{ job.services.mysql.ports['3306'] }})/dogmatiq"
         DOGMATIQ_TEST_DSN_MARIADB_MYSQL: "root:rootpass@tcp(127.0.0.1:${{ job.services.mariadb.ports['3306'] }})/dogmatiq"
         DOGMATIQ_TEST_DSN_POSTGRESQL_POSTGRES: "user=postgres password=rootpass sslmode=disable port=${{ job.services.postgres.ports['5432'] }}"
         DOGMATIQ_TEST_DSN_POSTGRESQL_PGX: "postgres://postgres:rootpass@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/?sslmode=disable"
@@ -56,6 +72,7 @@ jobs:
       run: make test
       env:
         CGO_ENABLED: "0"
+        DOGMATIQ_TEST_DSN_MYSQL_MYSQL: "root:rootpass@tcp(127.0.0.1:${{ job.services.mysql.ports['3306'] }})/dogmatiq"
         DOGMATIQ_TEST_DSN_MARIADB_MYSQL: "root:rootpass@tcp(127.0.0.1:${{ job.services.mariadb.ports['3306'] }})/dogmatiq"
         DOGMATIQ_TEST_DSN_POSTGRESQL_POSTGRES: "user=postgres password=rootpass sslmode=disable port=${{ job.services.postgres.ports['5432'] }}"
         DOGMATIQ_TEST_DSN_POSTGRESQL_PGX: "postgres://postgres:rootpass@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/?sslmode=disable"

--- a/docker-stack.test.yml
+++ b/docker-stack.test.yml
@@ -1,8 +1,8 @@
 version: "3.7"
 
 services:
-  mariadb:
-    image: mariadb:10.4
+  mysql:
+    image: mysql:8
     environment:
       MYSQL_ROOT_PASSWORD: rootpass
       MYSQL_DATABASE: dogmatiq
@@ -11,7 +11,20 @@ services:
     ports:
     - "3306:3306/tcp"
     volumes:
+    - mysql:/var/lib/mysql
+
+  mariadb:
+    image: mariadb:10.4
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: dogmatiq
+      MYSQL_USER: dogmatiq
+      MYSQL_PASSWORD: dogmatiq
+    ports:
+    - "3307:3306/tcp"
+    volumes:
     - mariadb:/var/lib/mysql
+
   postgres:
     image: postgres:12.0-alpine
     environment:
@@ -22,5 +35,6 @@ services:
     - postgres:/var/lib/postgresql/data
 
 volumes:
+  mysql:
   mariadb:
   postgres:

--- a/sql/driver.go
+++ b/sql/driver.go
@@ -50,6 +50,15 @@ type Driver interface {
 
 // NewDriver returns the appropriate driver implementation to use with the given
 // database.
+//
+// The following database products and SQL drivers are officially supported:
+//
+// MySQL and MariaDB via the "mysql" ("github.com/go-sql-driver/mysql") driver.
+//
+// PostgreSQL via the "postgres" (github.com/lib/pq) and "pgx"
+// (github.com/jackc/pgx) drivers.
+//
+// SQLite via the "sqlite3" (github.com/mattn/go-sqlite3) driver (requires CGO).
 func NewDriver(db *sql.DB) (Driver, error) {
 	if mysql.IsCompatibleWith(db) {
 		return &mysql.Driver{}, nil

--- a/sql/internal/drivertest/db.go
+++ b/sql/internal/drivertest/db.go
@@ -18,6 +18,9 @@ import (
 type Product string
 
 const (
+	// MySQL is the product enumeration value for MariaDB.
+	MySQL Product = "mysql"
+
 	// MariaDB is the product enumeration value for MariaDB.
 	MariaDB Product = "mariadb"
 
@@ -47,8 +50,10 @@ func DSN(prod Product, driver string) (string, func()) {
 	}
 
 	switch key {
-	case "DOGMATIQ_TEST_DSN_MARIADB_MYSQL":
+	case "DOGMATIQ_TEST_DSN_MYSQL_MYSQL":
 		return "root:rootpass@tcp(127.0.0.1:3306)/dogmatiq", func() {}
+	case "DOGMATIQ_TEST_DSN_MARIADB_MYSQL":
+		return "root:rootpass@tcp(127.0.0.1:3307)/dogmatiq", func() {}
 	case "DOGMATIQ_TEST_DSN_POSTGRESQL_POSTGRES":
 		return "user=postgres password=rootpass sslmode=disable", func() {}
 	case "DOGMATIQ_TEST_DSN_POSTGRESQL_PGX":


### PR DESCRIPTION
<!------------------------------------------------------------------------------

A GOOD PULL REQUEST:

- Is small.
- Contains a single change that makes sense in isolation.
- Makes the code better.


A GOOD PULL REQUEST TITLE:

- Completes the sentence "If applied, this PR will ...".
- Is less than 50 characters.

Example: Allow for compaction of projections.


BEFORE YOU SUBMIT A PULL REQUEST:

- Read the contribution guidelines at https://github.com/dogmatiq/.github/CONTRIBUTING.md.
- Know what you are submitting.
- Review the entire diff line-by-line. If this is too hard, your PR is too big.

------------------------------------------------------------------------------->

#### What change does this introduce?

This PR adds tests for projectionkit's "mysql" driver under vanilla MySQL.
<!--

Briefly describe the change you've made in terms of the features or behavior it
introduces or modifies.

-- EXAMPLE:

This PR adds support for "projection compaction" which is an operation on
projections that can be invoked by the engine to clean up any "unused" or
"oversized" projection data.

-->

#### What issues does this relate to?

Fixes #68 
<!--

Link to any GitHub issues that are relevant to these changes. Use the "fixes"
keyword if you believe an issue to be completely addressed by this PR.

-- EXAMPLE:

Fixes #123
Partially addresses #456

-->

#### Why make this change?

To ensure projection kit works with vanilla MySQL as well as MariaDB.
<!--

Briefly describe the rationale behind making this change.

-- EXAMPLE

By making this a first-class feature we encourage the developer to think about
the lifetime of their projection data, which might otherwise go unaddressed.

-->

#### Is there anything you are unsure about?

No
<!--

This is a place to ask any specific questions about the changes you've made that
you'd like to see addressed by the project's maintainers before they begin
reviewing.

Consider submitting a draft PR if you require feedback about incomplete changes.

-- EXAMPLE

Should `Compact()` implementations be required to impose their own timeout?

-->
