### PR TITLE
No compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - Add support for `github.com/jackc/pgx` PostgreSQL driver
-- Add embeddable `NoCompactBehavior` for boltdb and sql
+- Add `sql.NoCompactBehavior` and `boltdb.NoCompactBehavior` embeddable structs
 
 ## [0.5.0] - 2020-11-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - Add support for `github.com/jackc/pgx` PostgreSQL driver
+- Add embeddable `NoCompactBehavior` for boltdb and sql
 
 ## [0.5.0] - 2020-11-13
 

--- a/boltdb/handler.go
+++ b/boltdb/handler.go
@@ -78,3 +78,19 @@ type MessageHandler interface {
 	// engine-defined. It MAY be called concurrently with any other method.
 	Compact(ctx context.Context, db *bolt.DB, s dogma.ProjectionCompactScope) error
 }
+
+// NoCompactBehavior can be embedded in MessageHandler implementations
+// to indicate that the projection does not require its data to be compacted.
+//
+// It provides an implementation of MessageHandler.Compact() that
+// always returns a nil error.
+type NoCompactBehavior struct{}
+
+// Compact returns nil.
+func (NoCompactBehavior) Compact(
+	ctx context.Context,
+	db *bolt.DB,
+	s dogma.ProjectionCompactScope,
+) error {
+	return nil
+}

--- a/boltdb/handler_test.go
+++ b/boltdb/handler_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/dogmatiq/projectionkit/boltdb"
 )
 
-func TestNoCompactBehaviorBehavior_Compact_ReturnsNil(t *testing.T) {
+func TestNoCompactBehavior_Compact_ReturnsNil(t *testing.T) {
 	var v NoCompactBehavior
 
 	err := v.Compact(context.Background(), nil, nil)

--- a/boltdb/handler_test.go
+++ b/boltdb/handler_test.go
@@ -1,0 +1,18 @@
+package boltdb_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/dogmatiq/projectionkit/boltdb"
+)
+
+func TestNoCompactBehaviorBehavior_Compact_ReturnsNil(t *testing.T) {
+	var v NoCompactBehavior
+
+	err := v.Compact(context.Background(), nil, nil)
+
+	if err != nil {
+		t.Fatal("unexpected error returned")
+	}
+}

--- a/sql/handler.go
+++ b/sql/handler.go
@@ -78,3 +78,19 @@ type MessageHandler interface {
 	// engine-defined. It MAY be called concurrently with any other method.
 	Compact(ctx context.Context, db *sql.DB, s dogma.ProjectionCompactScope) error
 }
+
+// NoCompactBehavior can be embedded in MessageHandler implementations
+// to indicate that the projection does not require its data to be compacted.
+//
+// It provides an implementation of MessageHandler.Compact() that
+// always returns a nil error.
+type NoCompactBehavior struct{}
+
+// Compact returns nil.
+func (NoCompactBehavior) Compact(
+	ctx context.Context,
+	db *sql.DB,
+	s dogma.ProjectionCompactScope,
+) error {
+	return nil
+}

--- a/sql/handler_test.go
+++ b/sql/handler_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/dogmatiq/projectionkit/sql"
 )
 
-func TestNoCompactBehaviorBehavior_Compact_ReturnsNil(t *testing.T) {
+func TestNoCompactBehavior_Compact_ReturnsNil(t *testing.T) {
 	var v NoCompactBehavior
 
 	err := v.Compact(context.Background(), nil, nil)

--- a/sql/handler_test.go
+++ b/sql/handler_test.go
@@ -1,0 +1,18 @@
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/dogmatiq/projectionkit/sql"
+)
+
+func TestNoCompactBehaviorBehavior_Compact_ReturnsNil(t *testing.T) {
+	var v NoCompactBehavior
+
+	err := v.Compact(context.Background(), nil, nil)
+
+	if err != nil {
+		t.Fatal("unexpected error returned")
+	}
+}


### PR DESCRIPTION
#### What change does this introduce?

This PR adds embeddable `NoCompactBehavior` structs that provide a no-op `Compact()` method for both BoltDB and SQL projections

#### What issues does this relate to?

Fixes #66

#### Why make this change?

The Dogma projection API was updated to add support for a `Compact()` method on projection message handlers. This change is to add no-op embeddable behaviors for sql and boltdb based projections.

#### Is there anything you are unsure about?

No.
