### PR TITLE
Explicitly support `nil` databases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Changed
+
+- `boltdb.New()` and `sql.New()` now explicitly accept a `nil` database
+
 ## [0.5.1] - 2020-11-14
 
 ### Added

--- a/boltdb/adaptor.go
+++ b/boltdb/adaptor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/projectionkit/internal/identity"
+	"github.com/dogmatiq/projectionkit/internal/unboundhandler"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -17,11 +18,19 @@ type adaptor struct {
 	key string
 }
 
-// New returns a new projection message handler that uses the given database.
+// New returns a new Dogma projection message handler by binding a
+// BoltDB-specific projection handler to a BoltDB database.
+//
+// If db is nil the returned handler will return an error whenever an operation
+// that requires the database is performed.
 func New(
 	db *bolt.DB,
 	h MessageHandler,
 ) dogma.ProjectionMessageHandler {
+	if db == nil {
+		return unboundhandler.New(h)
+	}
+
 	return &adaptor{
 		MessageHandler: h,
 		db:             db,

--- a/boltdb/adaptor_test.go
+++ b/boltdb/adaptor_test.go
@@ -59,6 +59,15 @@ var _ = Describe("type adaptor", func() {
 		},
 	)
 
+	Describe("func New()", func() {
+		It("returns an unbound handler if the database is nil", func() {
+			adaptor = New(nil, handler)
+
+			err := adaptor.Compact(context.Background(), nil)
+			Expect(err).To(MatchError("projection handler has not been bound to a database"))
+		})
+	})
+
 	Describe("func HandleEvent()", func() {
 		It("does not produce errors when OCC parameters are supplied correctly", func() {
 			By("persisting the initial resource version")

--- a/boltdb/adaptor_test.go
+++ b/boltdb/adaptor_test.go
@@ -63,7 +63,10 @@ var _ = Describe("type adaptor", func() {
 		It("returns an unbound handler if the database is nil", func() {
 			adaptor = New(nil, handler)
 
-			err := adaptor.Compact(context.Background(), nil)
+			err := adaptor.Compact(
+				context.Background(),
+				nil, // scope
+			)
 			Expect(err).To(MatchError("projection handler has not been bound to a database"))
 		})
 	})
@@ -239,7 +242,7 @@ var _ = Describe("type adaptor", func() {
 		})
 	})
 
-	Describe("func Closure()", func() {
+	Describe("func Compact()", func() {
 		It("forwards to the handler", func() {
 			handler.CompactFunc = func(
 				_ context.Context,

--- a/internal/unboundhandler/ginkgo_test.go
+++ b/internal/unboundhandler/ginkgo_test.go
@@ -1,0 +1,15 @@
+package unboundhandler_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/internal/unboundhandler/handler.go
+++ b/internal/unboundhandler/handler.go
@@ -1,0 +1,63 @@
+package unboundhandler
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+)
+
+// UpstreamHandler is a handler that adheres to one of the MessageHandler
+// interfaces within projectionkit.
+type UpstreamHandler interface {
+	Configure(dogma.ProjectionConfigurer)
+	TimeoutHint(dogma.Message) time.Duration
+}
+
+// errUnbound is returned by any projection operation that requires a database.
+var errUnbound = errors.New("projection handler has not been bound to a database")
+
+// handler is an implementation of dogma.ProjectionMessageHandler that
+// represents a projectionkit handler that has not been bound to a database.
+type handler struct {
+	Upstream UpstreamHandler
+}
+
+// New adapts a projectionkit message handler that has not been bound to a
+// specific database into a Dogma projection message handler.
+//
+// Any operations that require access to the database return an error.
+func New(h UpstreamHandler) dogma.ProjectionMessageHandler {
+	return handler{h}
+}
+
+func (h handler) Configure(c dogma.ProjectionConfigurer) {
+	h.Upstream.Configure(c)
+}
+
+func (h handler) HandleEvent(
+	_ context.Context,
+	_, _, _ []byte,
+	_ dogma.ProjectionEventScope,
+	_ dogma.Message,
+) (bool, error) {
+	return false, errUnbound
+}
+
+func (h handler) ResourceVersion(context.Context, []byte) ([]byte, error) {
+	return nil, errUnbound
+
+}
+
+func (h handler) CloseResource(context.Context, []byte) error {
+	return errUnbound
+}
+
+func (h handler) TimeoutHint(m dogma.Message) time.Duration {
+	return h.Upstream.TimeoutHint(m)
+}
+
+func (h handler) Compact(context.Context, dogma.ProjectionCompactScope) error {
+	return errUnbound
+}

--- a/internal/unboundhandler/handler_test.go
+++ b/internal/unboundhandler/handler_test.go
@@ -1,0 +1,79 @@
+package unboundhandler_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
+	"github.com/dogmatiq/projectionkit/internal/identity"
+	. "github.com/dogmatiq/projectionkit/internal/unboundhandler"
+	_ "github.com/mattn/go-sqlite3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Handler", func() {
+	var (
+		upstream *ProjectionMessageHandler
+		handler  dogma.ProjectionMessageHandler
+	)
+
+	BeforeEach(func() {
+		upstream = &ProjectionMessageHandler{
+			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+				c.Identity("<name>", "<key>")
+			},
+		}
+		handler = New(upstream)
+	})
+
+	Describe("func Configure()", func() {
+		It("forwards to the upstream handler", func() {
+			k := identity.Key(handler)
+			Expect(k).To(Equal("<key>"))
+		})
+	})
+
+	Describe("func HandleEvent()", func() {
+		It("returns an error", func() {
+			_, err := handler.HandleEvent(context.Background(), nil, nil, nil, nil, nil)
+			Expect(err).To(MatchError("projection handler has not been bound to a database"))
+		})
+	})
+
+	Describe("func ResourceVersion()", func() {
+		It("returns an error", func() {
+			_, err := handler.ResourceVersion(context.Background(), nil)
+			Expect(err).To(MatchError("projection handler has not been bound to a database"))
+		})
+	})
+
+	Describe("func CloseResource()", func() {
+		It("returns an error", func() {
+			err := handler.CloseResource(context.Background(), nil)
+			Expect(err).To(MatchError("projection handler has not been bound to a database"))
+		})
+	})
+
+	Describe("func TimeoutHint()", func() {
+		It("forwards to the upstream handler", func() {
+			upstream.TimeoutHintFunc = func(
+				m dogma.Message,
+			) time.Duration {
+				Expect(m).To(Equal(MessageA1))
+				return 10 * time.Second
+			}
+
+			d := handler.TimeoutHint(MessageA1)
+			Expect(d).To(Equal(10 * time.Second))
+		})
+	})
+
+	Describe("func Compact()", func() {
+		It("returns an error", func() {
+			err := handler.Compact(context.Background(), nil)
+			Expect(err).To(MatchError("projection handler has not been bound to a database"))
+		})
+	})
+})

--- a/sql/adaptor.go
+++ b/sql/adaptor.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/projectionkit/internal/identity"
+	"github.com/dogmatiq/projectionkit/internal/unboundhandler"
 )
 
 // adaptor adapts an sql.ProjectionMessageHandler to the
@@ -18,14 +19,23 @@ type adaptor struct {
 	driver Driver
 }
 
-// New returns a new projection message handler that uses the given database.
+// New returns a new Dogma projection message handler by binding an SQL-specific
+// projection handler to an SQL database.
 //
-// If d is nil, the appropriate default driver for db is used, if recognized.
+// If db is nil the returned handler will return an error whenever an operation
+// that requires the database is performed.
+//
+// If d is nil, the appropriate default driver is selected automatically if
+// possible.
 func New(
 	db *sql.DB,
 	h MessageHandler,
 	d Driver,
 ) (dogma.ProjectionMessageHandler, error) {
+	if db == nil {
+		return unboundhandler.New(h), nil
+	}
+
 	if d == nil {
 		var err error
 		d, err = NewDriver(db)

--- a/sql/adaptor_test.go
+++ b/sql/adaptor_test.go
@@ -52,7 +52,20 @@ var _ = Describe("type adaptor", func() {
 		},
 	)
 
-	Describe("func Closure()", func() {
+	Describe("func New()", func() {
+		It("returns an unbound handler if the database is nil", func() {
+			adaptor, err := New(nil, handler, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = adaptor.Compact(
+				context.Background(),
+				nil, // scope
+			)
+			Expect(err).To(MatchError("projection handler has not been bound to a database"))
+		})
+	})
+
+	Describe("func Compact()", func() {
 		It("forwards to the handler", func() {
 			handler.CompactFunc = func(
 				_ context.Context,


### PR DESCRIPTION
#### What change does this introduce?

This PR changes `boltdb.New()` and `sql.New()` to explicitly accept a `nil` database.

When these functions are passed a `nil` database, the handlers they return will always return an error when handling a message or doing any other operation that actually requires a database.

#### What issues does this relate to?

- Tangentially related to improvements discussed in #17 
- Useful to https://github.com/dogmatiq/configkit/issues/104

#### Why make this change?

This change allows you to consistently register the projections within an application even when you don't have the databases available (such as during testing, or whatever the scenario may be).

#### Is there anything you are unsure about?

No