### PR TITLE
Dynamic detection of unsupported "extended" resource operations.

### DIFF
--- a/resource/interfaces.go
+++ b/resource/interfaces.go
@@ -1,21 +1,32 @@
 package resource
 
-import "context"
+import (
+	"context"
+)
 
 // storer is an interface for projection message handlers that support
 // unconditionally storing resource versions.
+//
+// A type that implements this interface can still indicate a lack of support
+// for its operations by returning ErrNotSupported.
 type storer interface {
 	StoreResourceVersion(ctx context.Context, r, v []byte) error
 }
 
 // updater is an interface for projection message handlers that support updating
 // resource versions without handling an event.
+//
+// A type that implements this interface can still indicate a lack of support
+// for its operations by returning ErrNotSupported.
 type updater interface {
 	UpdateResourceVersion(ctx context.Context, r, c, n []byte) (bool, error)
 }
 
 // deleter is an interface for projection message handlers that support deleting
 // all notions of a resource from their data store.
+//
+// A type that implements this interface can still indicate a lack of support
+// for its operations by returning ErrNotSupported.
 type deleter interface {
 	DeleteResource(ctx context.Context, r []byte) error
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -26,7 +26,9 @@ func StoreVersion(
 ) error {
 	// If the handler directly supports storing versions, use that.
 	if s, ok := h.(storer); ok {
-		return s.StoreResourceVersion(ctx, r, v)
+		if err := s.StoreResourceVersion(ctx, r, v); err != ErrNotSupported {
+			return err
+		}
 	}
 
 	// If doesn't support the updater interface there's nothing more we can do.


### PR DESCRIPTION
#### What change does this introduce?

This PR allows implementations of the `resource.storer`, `updater` and `deleter` in the `resource` package to `ErrNotSupported` to indicate that an operation is not supported.

#### Why make this change?

The `resource` package provides "extended" operations for manipulating resource versions for maintenance purposes.

Previously, support for these extended operations was indicated by having a projection implement one or more of the resource.storer`, `updater` and `deleter` interfaces, that is, statically.  Allowing the methods of these interface to return `ErrNotSupported` makes it possible to determine lack of support dynamically, and thus allows for wrapping projection implementations in adaptors/decorators that are still capable of the underlying projection's extended operations when supported.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
